### PR TITLE
Revert "Remove golangci-lint from release action"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           go-version: 1.14
       -
+        name: golangci-lint
+        uses: golangci/golangci-lint-action@v1
+        with:
+          version: v1.30
+          args: --issues-exit-code=1
+      -
         name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v2


### PR DESCRIPTION
This commit reinstates running golangci-lint as part of the release process. This PR should be merged only after this project passes `golangci-lint run`.

This reverts commit d800366de204ab865ec15b5024e860ea7e89f87b.

Signed-off-by: Mark Peek <markpeek@vmware.com>