### PR TITLE
Do not persist external_id

### DIFF
--- a/wavefront/resource_cloud_integration.go
+++ b/wavefront/resource_cloud_integration.go
@@ -183,7 +183,6 @@ func encodeAwsIntegration(d *schema.ResourceData, integration *wavefront.CloudIn
 		d.Set("volume_selection_tags", integration.CloudWatch.VolumeSelectionTags)
 		d.Set("instance_selection_tags", integration.CloudWatch.InstanceSelectionTags)
 		d.Set("role_arn", integration.CloudWatch.BaseCredentials.RoleARN)
-		d.Set("external_id", integration.CloudWatch.BaseCredentials.ExternalID)
 		d.Set("point_tag_filter_regex", integration.CloudWatch.PointTagFilterRegex)
 	case "CLOUDTRAIL":
 		d.Set("region", integration.CloudTrail.Region)
@@ -191,11 +190,9 @@ func encodeAwsIntegration(d *schema.ResourceData, integration *wavefront.CloudIn
 		d.Set("bucket_name", integration.CloudTrail.BucketName)
 		d.Set("filter_rule", integration.CloudTrail.FilterRule)
 		d.Set("role_arn", integration.CloudTrail.BaseCredentials.RoleARN)
-		d.Set("external_id", integration.CloudTrail.BaseCredentials.ExternalID)
 	case "EC2":
 		d.Set("hostname_tags", integration.EC2.HostNameTags)
 		d.Set("role_arn", integration.EC2.BaseCredentials.RoleARN)
-		d.Set("external_id", integration.EC2.BaseCredentials.ExternalID)
 	default:
 		return fmt.Errorf("invalid service, expected one of CLOUDWATCH, CLOUDTRAIL, or EC2. got %s", integration.Service)
 	}


### PR DESCRIPTION
Do not persist external_id so it won't mark resources as changed all the time