### PR TITLE
AWS cloud int. to destroy / recreate on changed external_id

### DIFF
--- a/wavefront/resource_cloud_integration.go
+++ b/wavefront/resource_cloud_integration.go
@@ -183,6 +183,7 @@ func encodeAwsIntegration(d *schema.ResourceData, integration *wavefront.CloudIn
 		d.Set("volume_selection_tags", integration.CloudWatch.VolumeSelectionTags)
 		d.Set("instance_selection_tags", integration.CloudWatch.InstanceSelectionTags)
 		d.Set("role_arn", integration.CloudWatch.BaseCredentials.RoleARN)
+		d.Set("external_id", integration.CloudWatch.BaseCredentials.ExternalID)
 		d.Set("point_tag_filter_regex", integration.CloudWatch.PointTagFilterRegex)
 	case "CLOUDTRAIL":
 		d.Set("region", integration.CloudTrail.Region)
@@ -190,9 +191,11 @@ func encodeAwsIntegration(d *schema.ResourceData, integration *wavefront.CloudIn
 		d.Set("bucket_name", integration.CloudTrail.BucketName)
 		d.Set("filter_rule", integration.CloudTrail.FilterRule)
 		d.Set("role_arn", integration.CloudTrail.BaseCredentials.RoleARN)
+		d.Set("external_id", integration.CloudTrail.BaseCredentials.ExternalID)
 	case "EC2":
 		d.Set("hostname_tags", integration.EC2.HostNameTags)
 		d.Set("role_arn", integration.EC2.BaseCredentials.RoleARN)
+		d.Set("external_id", integration.EC2.BaseCredentials.ExternalID)
 	default:
 		return fmt.Errorf("invalid service, expected one of CLOUDWATCH, CLOUDTRAIL, or EC2. got %s", integration.Service)
 	}

--- a/wavefront/resource_cloud_integration_cloudtrail.go
+++ b/wavefront/resource_cloud_integration_cloudtrail.go
@@ -56,6 +56,7 @@ func resourceCloudIntegrationCloudTrail() *schema.Resource {
 			"external_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/wavefront/resource_cloud_integration_cloudwatch.go
+++ b/wavefront/resource_cloud_integration_cloudwatch.go
@@ -63,6 +63,7 @@ func resourceCloudIntegrationCloudWatch() *schema.Resource {
 			"external_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/wavefront/resource_cloud_integration_ec2.go
+++ b/wavefront/resource_cloud_integration_ec2.go
@@ -45,6 +45,7 @@ func resourceCloudIntegrationEc2() *schema.Resource {
 			"external_id": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 		},
 	}


### PR DESCRIPTION
A chnaged external ID for resource_cloud_integration_cloudtrail,
resource_cloud_integration_cloudwatch, or
resource_cloud_integration_ec2 should force a destroy/recreate as changing
external ID in a PUT request is an error.