### PR TITLE
Suppress Condition Comparason for Multi-Threshold Alert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+.envrc
 .terraform/
+.terraform.lock.hcl
 terraform.tfstate*
 terraform-provider-wavefront*
 crash.log
-main.tf
 .idea/*
 dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Steps
 
 * This is a good [blog post](https://www.terraform.io/guides/writing-custom-terraform-providers.html?) by Hashicorp to get started.
 * Looking at how existing [Providers](https://github.com/terraform-providers) work can be useful.
+* This is a good [blog post](https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/) to get some details on how to debug custom terraform provider.
 
 ## Setup
 
@@ -58,7 +59,7 @@ The `WAVEFRONT_ADDRESS` and `WAVEFRONT_TOKEN` environment variables are required
 export WAVEFRONT_ADDRESS=<your-account>.wavefront.com
 export WAVEFRONT_TOKEN=<your-wavefront-token>
 
-make acceptance
+make testacc
 ```
 
 ## Formatting

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    wavefront = {
+      source  = "vmware/wavefront",
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "wavefront" {
+  address = "<YOUR_WAVEFRONT_CLUSTER_ADDRESS>"
+  token   = "<YOUR_WAVEFRONT_CLUSTER_TOKEN>"
+}
+
+resource "wavefront_alert" "mac_cpu_usage_over_ninety_percent" {
+  name                   = "Mac CPU Usage Over 90%"
+  alert_type             = "THRESHOLD"
+  display_expression     = "100 - avg(ts(\"mac.cpu.usage.idle\", source=\"mac.host\"))"
+  conditions             = {
+    "severe"             = "100 - avg(ts(\"mac.cpu.usage.idle\", source=\"mac.host\")) > 90"
+  }
+  additional_information = "This is a sample alert created by terraform. It monitors the CPU Usage and fires when it's over 90%."
+  minutes                = 5
+  resolve_after_minutes  = 5
+  threshold_targets      = {
+    "severe"             = "alert_target@example.com"
+  }
+  tags                   = [
+    "example",
+    "cpu.usage"
+  ]
+}

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,37 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/vmware/terraform-provider-wavefront/wavefront"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
 			return wavefront.Provider()
 		},
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "vmware/wavefront", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	logFlags := log.Flags()
+	logFlags = logFlags &^ (log.Ldate | log.Ltime)
+	log.SetFlags(logFlags)
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
Since Alert V2, we force sync `condition` with `display_expression` in a multi-threshold alert.

This change suppresses the diff check for the `condition` field in a multi-threshold alert.