### PR TITLE
Threshold condition suppress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
+.envrc
 .terraform/
+.terraform.lock.hcl
 terraform.tfstate*
 terraform-provider-wavefront*
 crash.log
-main.tf
 .idea/*
 dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.1 (March 10, 2021)
+BUG FIXES:
+
+* Fix incompatibility issue between threshold alerts and new alert experience.
+* Update command in CONTRIBUTING.md.
+
 ## 3.0.0 (June 10, 2021)
 
 NOTES:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Steps
 
 * This is a good [blog post](https://www.terraform.io/guides/writing-custom-terraform-providers.html?) by Hashicorp to get started.
 * Looking at how existing [Providers](https://github.com/terraform-providers) work can be useful.
+* This is a good [blog post](https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/) to get some details on how to debug custom terraform provider.
 
 ## Setup
 
@@ -58,7 +59,7 @@ The `WAVEFRONT_ADDRESS` and `WAVEFRONT_TOKEN` environment variables are required
 export WAVEFRONT_ADDRESS=<your-account>.wavefront.com
 export WAVEFRONT_TOKEN=<your-wavefront-token>
 
-make acceptance
+make testacc
 ```
 
 ## Formatting

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ description: |-
 
 # Wavefront Provider
 
-> We released version 3.0.1 to address an incompatibility in version <= 3.0.0 between threshold alerts and our new alerting experience.
+> Version 3.0.1 addresses a compatibility issue with the new alerting experience.
 
 The Wavefront provider is used to interact with the Wavefront monitoring service. The
 provider needs to be configured with the proper credentials before it can be used.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@ description: |-
 
 # Wavefront Provider
 
+> We released version 3.0.1 to address an incompatibility in version <= 3.0.0 between threshold alerts and our new alerting experience.
+
 The Wavefront provider is used to interact with the Wavefront monitoring service. The
 provider needs to be configured with the proper credentials before it can be used.
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    wavefront = {
+      source  = "vmware/wavefront",
+      version = ">= 3.0.0"
+    }
+  }
+}
+
+provider "wavefront" {
+  address = "<YOUR_WAVEFRONT_CLUSTER_ADDRESS>"
+  token   = "<YOUR_WAVEFRONT_CLUSTER_TOKEN>"
+}
+
+resource "wavefront_alert" "mac_cpu_usage_over_ninety_percent" {
+  name                   = "Mac CPU Usage Over 90%"
+  alert_type             = "THRESHOLD"
+  display_expression     = "100 - avg(ts(\"mac.cpu.usage.idle\", source=\"mac.host\"))"
+  conditions             = {
+    "severe"             = "100 - avg(ts(\"mac.cpu.usage.idle\", source=\"mac.host\")) > 90"
+  }
+  additional_information = "This is a sample alert created by terraform. It monitors the CPU Usage and fires when it's over 90%."
+  minutes                = 5
+  resolve_after_minutes  = 5
+  threshold_targets      = {
+    "severe"             = "alert_target@example.com"
+  }
+  tags                   = [
+    "example",
+    "cpu.usage"
+  ]
+}

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/main.go
+++ b/main.go
@@ -1,15 +1,37 @@
 package main
 
 import (
+	"context"
+	"flag"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 	"github.com/vmware/terraform-provider-wavefront/wavefront"
 )
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debugMode bool
+
+	flag.BoolVar(&debugMode, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
 		ProviderFunc: func() *schema.Provider {
 			return wavefront.Provider()
 		},
-	})
+	}
+
+	if debugMode {
+		err := plugin.Debug(context.Background(), "vmware/wavefront", opts)
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+		return
+	}
+
+	logFlags := log.Flags()
+	logFlags = logFlags &^ (log.Ldate | log.Ltime)
+	log.SetFlags(logFlags)
+	plugin.Serve(opts)
 }

--- a/wavefront/resource_alert_test.go
+++ b/wavefront/resource_alert_test.go
@@ -226,6 +226,33 @@ func TestAccWavefrontAlert_Threshold(t *testing.T) {
 	})
 }
 
+func TestAccWavefrontAlert_ThresholdWithCondition(t *testing.T) {
+	var record wavefront.Alert
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckWavefrontAlertDestroy,
+		Steps: []resource.TestStep{
+			// change the condition and verify the condition change is ignored.
+			{
+				Config: testAccCheckWavefrontAlertThresholdChangeCondition(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckWavefrontAlertExists(
+						"wavefront_alert.test_threshold_alert_change_condition", &record),
+					testAccCheckWavefrontThresholdAlertAttributes(&record),
+
+					//Check against state that the attributes are as we expect
+					resource.TestCheckResourceAttr(
+						"wavefront_alert.test_threshold_alert_change_condition", "conditions.%", "3"),
+					resource.TestCheckResourceAttr(
+						"wavefront_alert.test_threshold_alert_change_condition", "threshold_targets.%", "1"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAlert_validateAlertConditions(t *testing.T) {
 
 	cases := []struct {
@@ -368,12 +395,16 @@ func testAccCheckWavefrontAlertAttributes(alert *wavefront.Alert) resource.TestC
 func testAccCheckWavefrontThresholdAlertAttributes(alert *wavefront.Alert) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
+		if alert.Condition != "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total )" {
+			return fmt.Errorf("bad value: %s", alert.Condition)
+		}
+
 		if val, ok := alert.Conditions["severe"]; ok {
 			if val != "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 80" {
 				return fmt.Errorf("bad value: %s", alert.Conditions["severe"])
 			}
 		} else {
-			return fmt.Errorf("target not set")
+			return fmt.Errorf("multi-threshold alert's conditions are not set")
 		}
 
 		return nil
@@ -623,6 +654,51 @@ resource "wavefront_alert" "test_threshold_alert" {
 	"severe" = "target:${wavefront_alert_target.test_target.id}"
   }
   
+  tags = [
+    "terraform"
+  ]
+}
+`
+}
+
+func testAccCheckWavefrontAlertThresholdChangeCondition() string {
+	return `
+resource "wavefront_alert_target" "test_target" {
+  name = "Terraform Test Target"
+  description = "Test target"
+  method = "EMAIL"
+  recipient = "test@example.com"
+  email_subject = "This is a test"
+  is_html_content = true
+  template = "{}"
+  triggers = [
+    "ALERT_OPENED",
+    "ALERT_RESOLVED"
+  ]
+}
+
+
+resource "wavefront_alert" "test_threshold_alert_change_condition" {
+  name = "Terraform Test Alert"
+  alert_type = "THRESHOLD"
+  additional_information = "This is a Terraform Test Alert"
+  # change in condition for multi-threshold alert takes no effect, wavefront backend will force sync the condition
+  # with display_expression
+  condition = "change_condition"
+  display_expression = "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total )"
+  minutes = 5
+  resolve_after_minutes = 5
+
+  conditions = {
+    "severe" = "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 80"
+    "warn" = "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 60"
+    "info" = "100-ts(\"cpu.usage_idle\", environment=preprod and cpu=cpu-total ) > 50"
+  }
+
+  threshold_targets = {
+	"severe" = "target:${wavefront_alert_target.test_target.id}"
+  }
+
   tags = [
     "terraform"
   ]

--- a/wavefront/resource_alert_test.go
+++ b/wavefront/resource_alert_test.go
@@ -242,7 +242,9 @@ func TestAccWavefrontAlert_ThresholdWithCondition(t *testing.T) {
 						"wavefront_alert.test_threshold_alert_change_condition", &record),
 					testAccCheckWavefrontThresholdAlertAttributes(&record),
 
-					//Check against state that the attributes are as we expect
+					// Check against state that the attributes are as we expect
+					// TODO: figure out why verification on `condition` using `resource.TestCheckResourceAttr` does not
+					//  work.
 					resource.TestCheckResourceAttr(
 						"wavefront_alert.test_threshold_alert_change_condition", "conditions.%", "3"),
 					resource.TestCheckResourceAttr(


### PR DESCRIPTION
Since Alert V2, we force sync condition with display_expression in a multi-threshold alert.

This change suppresses the diff check for the condition field in a multi-threshold alert.