### PR TITLE
upgrading golanci-lint version to 1.48

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.48
           skip-pkg-cache: true
           skip-build-cache: true
           args: --issues-exit-code=1


### PR DESCRIPTION
Upgrading golangci-lint version to 1.48. This fixes the build error with status code 137