### PR TITLE
Upgraded golangci-lint to address deprecation warning

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.52.2
+          version: v2.5.2
           skip-pkg-cache: true
           skip-build-cache: true
           args: --issues-exit-code=1


### PR DESCRIPTION
Older version of golangci-lint seems to have a deprecation warning that is blocking PR scans.

Upgrading to the latest 2.x version (3.x requires additional workflow changes).