### PR TITLE
adding alert_type check and empty check for target field

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,7 +10,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v2.5.2
+          version: v1.52.2
           skip-pkg-cache: true
           skip-build-cache: true
           args: --issues-exit-code=1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v2.5.2
+          version: v1.52.2
           skip-pkg-cache: true
           skip-build-cache: true
           args: --issues-exit-code=1

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -59,7 +59,7 @@ If absent or <= 0, no re-triggering occurs.
 * `severity` - (Optional, `CLASSIC` alerts only) - Severity of the alert, valid values are `INFO`, `SMOKE`, `WARN`, `SEVERE`.
 * `can_view` - (Optional) A list of users or groups that can view this resource.
 * `can_modify` - (Optional) A list of users or groups that can modify this resource.
-* `process_rate_minutes` - (Optional) The specified query is executed every `process_rate_minutes` minutes.
+* `process_rate_minutes` - (Optional) The specified query is executed every `process_rate_minutes` minutes. Default value is 5 minutes.
 
 
 ### Example

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -57,8 +57,8 @@ the same value as `minutes`.
 * `notification_resend_frequency_minutes` - (Optional) How often to re-trigger a continually failing alert. 
 If absent or <= 0, no re-triggering occurs.  
 * `severity` - (Optional, `CLASSIC` alerts only) - Severity of the alert, valid values are `INFO`, `SMOKE`, `WARN`, `SEVERE`.
-* `can_view` - (Optional) A list of users or groups that can view this resource.
-* `can_modify` - (Optional) A list of users or groups that can modify this resource.
+* `can_view` - (Optional) A list of valid users or groups that can view this resource on a tenant. Default is Empty list.
+* `can_modify` - (Optional) A list of valid users or groups that can modify this resource on a tenant.
 * `process_rate_minutes` - (Optional) The specified query is executed every `process_rate_minutes` minutes. Default value is 5 minutes.
 
 

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -37,7 +37,7 @@ The following arguments are supported:
 or `THRESHOLD`.
 * `minutes` - (Required) The number of consecutive minutes that a series matching the condition query must 
 evaluate to "true" (non-zero value) before the alert fires.
-* `target` - (Optional) A comma-separated list of the email address or integration endpoint 
+* `target` - (Optional, `CLASSIC` alerts only) A comma-separated list of the email address or integration endpoint 
 (such as PagerDuty or webhook) to notify when the alert status changes. Multiple target types can be in the list.
 Alert target format: ({email}|pd:{pd_key}|target:{alert-target-id}).
 * `condition` - (Optional) A Wavefront query that is evaluated at regular intervals (default is 1 minute).
@@ -56,7 +56,7 @@ query must evaluate to "false" (zero value) before the alert resolves.  When uns
 the same value as `minutes`.
 * `notification_resend_frequency_minutes` - (Optional) How often to re-trigger a continually failing alert. 
 If absent or <= 0, no re-triggering occurs.  
-* `severity` - (Optional) - Severity of the alert, valid values are `INFO`, `SMOKE`, `WARN`, `SEVERE`.
+* `severity` - (Optional, `CLASSIC` alerts only) - Severity of the alert, valid values are `INFO`, `SMOKE`, `WARN`, `SEVERE`.
 * `can_view` - (Optional) A list of users or groups that can view this resource.
 * `can_modify` - (Optional) A list of users or groups that can modify this resource.
 * `process_rate_minutes` - (Optional) The specified query is executed every `process_rate_minutes` minutes.

--- a/docs/resources/alert.md
+++ b/docs/resources/alert.md
@@ -45,7 +45,7 @@ The alert fires and notifications are triggered when a data series matching this
 to a non-zero value for a set number of consecutive minutes. 
 * `conditions` - (Optional, `THRESHOLD` alerts only) a string->string map of `severity` to `condition` 
 for which this alert will trigger.
-* `threshold_targets` - (Optional, `THRESHOLD` alerts only) Targets for severity
+* `threshold_targets` - (Optional, `THRESHOLD` alerts only) A string to string map of Targets for severity.
 * `additional_information` - (Optional) User-supplied additional explanatory information for this alert.
 Useful for linking runbooks, migrations, etc.
 * `display_expression` - (Optional) A second query whose results are displayed in the alert user

--- a/wavefront/resource_alert.go
+++ b/wavefront/resource_alert.go
@@ -98,6 +98,7 @@ func resourceAlert() *schema.Resource {
 			"process_rate_minutes": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Default:  5,
 			},
 		},
 	}

--- a/wavefront/resource_alert.go
+++ b/wavefront/resource_alert.go
@@ -197,13 +197,15 @@ func resourceAlertRead(d *schema.ResourceData, meta interface{}) error {
 	if tmpAlert.Target != "" && tmpAlert.AlertType == wavefront.AlertTypeClassic {
 		d.Set("target", tmpAlert.Target)
 	}
+	if tmpAlert.Severity != "" && tmpAlert.AlertType == wavefront.AlertTypeClassic {
+		d.Set("severity", tmpAlert.Severity)
+	}
 	d.Set("condition", trimSpaces(tmpAlert.Condition))
 	d.Set("additional_information", trimSpaces(tmpAlert.AdditionalInfo))
 	d.Set("display_expression", trimSpaces(tmpAlert.DisplayExpression))
 	d.Set("minutes", tmpAlert.Minutes)
 	d.Set("resolve_after_minutes", tmpAlert.ResolveAfterMinutes)
 	d.Set("notification_resend_frequency_minutes", tmpAlert.NotificationResendFrequencyMinutes)
-	d.Set("severity", tmpAlert.Severity)
 	d.Set("tags", tmpAlert.Tags)
 	d.Set("alert_type", tmpAlert.AlertType)
 	d.Set("conditions", tmpAlert.Conditions)

--- a/wavefront/resource_alert.go
+++ b/wavefront/resource_alert.go
@@ -194,7 +194,9 @@ func resourceAlertRead(d *schema.ResourceData, meta interface{}) error {
 	// Use the Wavefront ID as the Terraform ID
 	d.SetId(*tmpAlert.ID)
 	d.Set("name", tmpAlert.Name)
-	d.Set("target", tmpAlert.Target)
+	if tmpAlert.Target != "" && tmpAlert.AlertType == wavefront.AlertTypeClassic {
+		d.Set("target", tmpAlert.Target)
+	}
 	d.Set("condition", trimSpaces(tmpAlert.Condition))
 	d.Set("additional_information", trimSpaces(tmpAlert.AdditionalInfo))
 	d.Set("display_expression", trimSpaces(tmpAlert.DisplayExpression))


### PR DESCRIPTION
Issue: terraform plan shows configuration changed even if there is no change in configuration.
Reason: Wavefront GET Api call returns a response that doesn't contain target field for alert_type THRESHOLD. Target field is only available if alert_type is CLASSIC

- ProcessRateMinutes is updated with default value to 5. This is default value set by wavefront POST api. If user doesn't give processRateMinute in resource configuration, default value is updated by POST Api. And when terraform plan is run, it shows changed configuration for the field.