### PR TITLE
Cleanup documentation and fix broken example usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,76 +1,30 @@
 # Contributing
 
 We welcome contributors to this Terraform Provider, and we'll do our best to review and merge all requests.
-Adding missing features as per the [Wavefront API](https://www.wavefront.com/api/) or bug fixes will be welcomed,
-functional changes will require discussion.
+Adding missing features as per the [Wavefront API](https://www.wavefront.com/api/) or bug fixes will be welcomed.
+Any functional changes will require discussion.
 
 We make use of [go-wavefront-management-api](https://github.com/WavefrontHQ/go-wavefront-management-api) to abstract the API from the provider.
 New features and bug fixes will likely require updates to go-wavefront client.
 
-Steps
+## Opening Issues
+If you encounter a bug or you are making a feature request, please open an issue in this repo.
 
-1. Open an Issue to track the change
-2. Fork the repository
-3. Make your changes
-4. Submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
+## Making Pull Requests
+1. Fork the repository
+1. Create a new branch for your change
+1. Make your changes and submit a [Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/)
 
-## Resources
+Before submitting a pull request, please ensure that unit tests pass. Refer to the [README.md](./README.md) for instructions on running unit tests.
+
+We will review your pull request and provide feedback.
+
+## Versioning
+
+We use [Semantic Versioning](http://semver.org/) on this project. The version is located inside the `version` file, in the root of the repository, in the format `vMajor.Minor.Patch`. Update this version as required.
+## Helpful Resources for Provider Development
 
 * This is a good [blog post](https://www.terraform.io/guides/writing-custom-terraform-providers.html?) by Hashicorp to get started.
 * Looking at how existing [Providers](https://github.com/terraform-providers) work can be useful.
 * This is a good [blog post](https://opencredo.com/blogs/running-a-terraform-provider-with-a-debugger/) to get some details on how to debug custom terraform provider.
 
-## Setup
-
-Ensure you have Go [installed and correctly setup](https://golang.org/doc/install).
-
-Fetch your fork of the - [repository](github.com/WavefrontHQ/terraform-provider-wavefront)
-`go get github.com/<your_account>/terraform-provider-wavefront`
-
-Build the current version to ensure you're correctly setup `make build`. This will create two binaries in the form of terraform-provider-wavefront_version_os_arch in the root of the repository, one for Darwin amd64 and one for Linux amd64, if you're using a different operating system or architecture, then you will need to update the build step of the makefile to also [build a binary for your OS and architecture](https://www.digitalocean.com/community/tutorials/how-to-build-go-executables-for-multiple-platforms-on-ubuntu-16-04).
-
-Now that you have a binary, you should attempt to run it and expect to see a message similar to the one below.
-
-``` shell
-./terraform-provider-wavefront_v0.1.2_darwin_amd64
-This binary is a plugin. These are not meant to be executed directly.
-Please execute the program that consumes these plugins, which will
-load any plugins automatically
-```
-
-## Versioning
-
-We use [Semantic Versioning](http://semver.org/) on this project. The version is located inside the `version` file, in the root of the repository, in the format `vMajor.Minor.Patch`, update this version as required.
-
-## Dependencies
-
-We use [Go Vendor](https://github.com/kardianos/govendor) to manage dependencies. Any dependencies that you add or update should be reflected within vendor and pushed along with your changes.
-
-## Unit Testing
-
-Unit Tests should be written where required and can be run from `make test`. The core functionality of the provider (Read, Create, Update, Delete and Import of resources is best tested via integration tests), but any supporting function should be unit tested.
-
-`make test` does not run acceptance tests.
-
-## Acceptance Testing
-
-Acceptance Tests are required for the Read, Create, Update, Delete and Import of resources. To run the acceptance tests, you should have access to a Wavefront account.
-
-The `WAVEFRONT_ADDRESS` and `WAVEFRONT_TOKEN` environment variables are required in order for the tests to run.
-
-```shell
-export WAVEFRONT_ADDRESS=<your-account>.wavefront.com
-export WAVEFRONT_TOKEN=<your-wavefront-token>
-
-make testacc
-```
-
-## Formatting
-
-`make fmt` will ensure that your code is correctly formatted. The build, test and acceptance stages of make will also run a fmt check and let you know if you need to run `make fmt`
-
-## Running Locally
-
-You can test the changes locally by building the plugin `make build`. Once you have the plugin you should remove the `_os_arch` from the end of the file name and place it in `~/.terraform.d/plugins` which is where `terraform init` will look for plugins.
-
-Valid provider file names are `terraform-provider-NAME_X.X.X` or `terraform-provider-NAME_vX.X.X`

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,6 @@ description: |-
 
 # Wavefront Provider
 
-> Version 3.0.1 addresses a compatibility issue with the new alerting experience.
-
 The Wavefront provider is used to interact with the Wavefront monitoring service. The
 provider needs to be configured with the proper credentials before it can be used.
 
@@ -18,9 +16,16 @@ Use the navigation on the left to read about the available resources.
 
 ```hcl
 # Configure the Wavefront provider
-provider "wavefront" {
-  version = "~> 3.0"
+terraform {
+  required_providers {
+    wavefront = {
+      source  = "vmware/wavefront"
+      version = "~> 5.0.5"
+    }
+  }
 }
+
+provider "wavefront" {}
 
 resource "wavefront_alert" "test_alert" {
   name                   = "High CPU Alert"


### PR DESCRIPTION
Updated documentation:
- Follow the DRY principle.
- Implement a separation of concerns so that the:
    - The `README.md` contains information related to **_developing_** and **_building_** the provider.
    - The `CONTRIBUTING.md` contains information related to **_contributing_** to the provider.
    - The `docs/index.md` contains information related to **_using_** the provider to manage Aria Operations for Applications resources.
- Fix the example usage in the `docs/index.md` file.

Signed-off-by: Feargus O'Gorman <feargusog@gmail.com>